### PR TITLE
Charon credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.retry
 .vault_password.txt
 pontus.larsson_medsci.uu.se.key
+charon_credentials.yml

--- a/README.md
+++ b/README.md
@@ -25,13 +25,8 @@ At the moment there has also been manual steps involved when downloading the tes
 - Requires the data record SQL database to be setup. Using `/lupus/ngi//db//isaks_db.sql` at the moment. 
 - Requires a working connection to `charon` or `charon-dev` with suitable API token. For now we're using a reverse SSH tunnel + header-rewriting HTTP proxy for reaching charon-dev. 
 - Requires a valid GATK key placed under `roles/piper/files`, and that the filename is specified in the `gatk_key` variable in `host_vars/127.0.0.1`. 
-
-Quick steps: 
-
-On irma login node, make sure that we have a Caddyfile with appropriate proxy settings. Running the binary `caddy` will load the configs and start proxying traffic between the two port numbers mentioned in the config file. 
-
-For this to we also have to have an SSH tunnel up and running from nestor to irma. Something like `ssh johanhe@irma1 -R *:4242:charon-dev.scilifelab.se:80` on nestor will portforward 4242 on irma1 to charon-dev:80.
+- Requires a `charon_credentials.yml` to be placed under `roles/ngi_pipeline/defaults/` with appropriate values set for the variables `charon_base_url`, `charon_api_token_upps` and `charon_api_token_sthlm`. (TODO: Contemplate whether this should be structured otherwise) 
 
 ## Note on re-compiling software
 
-Need to remove the file that is specified in the task's `creates=` field. Otherwise the compile step will be ignored.  
+FIXME: Need to remove the file that is specified in the task's `creates=` field. Otherwise the compile step will be ignored.  

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ At the moment there has also been manual steps involved when downloading the tes
 
 - Requires the data record SQL database to be setup. Using `/lupus/ngi//db//isaks_db.sql` at the moment. 
 - Requires a working connection to `charon` or `charon-dev` with suitable API token. For now we're using a reverse SSH tunnel + header-rewriting HTTP proxy for reaching charon-dev. 
-- Requires a valid GATK key placed under `roles/piper/files`, and that the filename is specified in the `gatk_key` variable in `host_vars/127.0.0.1`. 
-- Requires a `charon_credentials.yml` to be placed under `roles/ngi_pipeline/defaults/` with appropriate values set for the variables `charon_base_url`, `charon_api_token_upps` and `charon_api_token_sthlm`. (TODO: Contemplate whether this should be structured otherwise) 
+- Requires a valid GATK key placed under `playbooks/files`, and that the filename is specified in the `gatk_key` variable in `host_vars/127.0.0.1/main.yml`. 
+- Requires a `charon_credentials.yml` to be placed under `host_vars/127.0.0.1/` with appropriate values set for the variables `charon_base_url`, `charon_api_token_upps` and `charon_api_token_sthlm`. (TODO: Contemplate whether this should be structured otherwise) 
 
 ## Note on re-compiling software
 

--- a/host_vars/127.0.0.1
+++ b/host_vars/127.0.0.1
@@ -1,8 +1,5 @@
 ---
 
-# TODO: We might want to lift out some of these into group_vars/all
-# TODO: We might want to introduce an inventory group for production instead
-
 # For now, values here should be updated accordingly when user develops locally. 
 
 # root_path should be changed to suitable value when e.g. deploying locally
@@ -36,11 +33,9 @@ ngi_piper_bin_dest: "{{ root_path }}/sw/piper"
 ngi_piper_version: 051ca55f20949279b68fc1c96ce071b117f57a05
 
 # TODO: Where to store API token? How to reach charon-dev, if necessary? 
-charon_api_token_sthlm: FOOBAR 
-charon_api_token_upps: FOOBAR
-#Referring to dev instance for safety purposes
-charon_base_url: http://charon-dev.scilifelab.se/
+# charon settings are fetched from roles/ngi_pipeline/defaults/charon_credentials.yml for now. 
 
+# TODO: Move these settings to somewhere else? 
 gatk_bundle_b37_origin: "/sw/data/uppnex/reference/biodata/GATK/ftp.broadinstitute.org/bundle/2.8/b37/"
 gatk_bundle_b37: "{{ root_path }}/piper_resources/gatk_bundle/2.8/b37"
 gatk_bundle_hg19: "{{ root_path }}/piper_references/gatk_bundle/2.8/hg19"

--- a/host_vars/127.0.0.1/main.yml
+++ b/host_vars/127.0.0.1/main.yml
@@ -33,7 +33,8 @@ ngi_piper_bin_dest: "{{ root_path }}/sw/piper"
 ngi_piper_version: 051ca55f20949279b68fc1c96ce071b117f57a05
 
 # TODO: Where to store API token? How to reach charon-dev, if necessary? 
-# charon settings are fetched from roles/ngi_pipeline/defaults/charon_credentials.yml for now. 
+# charon settings are fetched from charon_credentials.yml for now, 
+# that is not checked into repo.  
 
 # TODO: Move these settings to somewhere else? 
 gatk_bundle_b37_origin: "/sw/data/uppnex/reference/biodata/GATK/ftp.broadinstitute.org/bundle/2.8/b37/"

--- a/roles/piper/tasks/main.yml
+++ b/roles/piper/tasks/main.yml
@@ -84,7 +84,7 @@
 
 - name: deploy gatk license key 
   copy:
-    src: "{{ gatk_key }}"
+    src: "files/{{ gatk_key }}"
     dest: "{{ root_path }}/piper_resources/{{ gatk_key }}" 
   tags: ngi_piper
  


### PR DESCRIPTION
Requires a file `charon_credentials.yml` to be put under `host_vars/127.0.0.1/`, because it wasn't possible to have several var files under `roles/ngi_pipeline/defaults` (a `main.yml` already exists there). 

As a consequence `host_vars/127.0.0.1.yml` is also renamed to `host_vars/127.0.0.1/main.yml`, and the gatk key is now supposed to be placed under `playbooks/files` instead of `roles/piper/files` to make it a little bit more similar to the charon credentials. 