### PR TITLE
Move db log

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Finnally the setgid flag was set by running `chmod -R g+s /lupus/ngi/sw/ /lupus/
 - Requires a `charon_credentials.yml` to be placed under `host_vars/127.0.0.1/` with appropriate values set for the variables `charon_base_url`, `charon_api_token_upps` and `charon_api_token_sthlm`. (TODO: Contemplate whether this should be structured otherwise) 
 - For deploying sw the user needs to be in both the `ngi-sw` and the `ngi` groups. Everything under `/lupus/ngi` will be owned by `ngi-sw`, except the `db` and `log` dirs that will be owned by `ngi`. That way a select few people can write new programs and configs, but all NGI functional accounts (`funk_004`, `funk_006` etc) can write log files, to the SQL database, etc. 
 
-Two manual steps are also needed for each func account. In respective `~/.bashrc` the following snippet needs to be added: 
+Three manual steps are also needed for each func account. In respective `~/.bashrc` the following snippet needs to be added: 
 
 	# Enter the ngi_pipeline working environment
 	source /lupus/ngi/conf/sourceme_<site>.sh
@@ -49,6 +49,8 @@ Two manual steps are also needed for each func account. In respective `~/.bashrc
 where `<site>` should be `upps` for `funk_004', and `sthlm` for `funk_006`. 
 
 Then to get the crontab for each func account loaded a manual `crontab /lupus/ngi/conf/crontab_<site>` needs to be run. The crontab files includes an autoreload, so next time a new versoin of the crontab is deployed the crontab for the func account should after a while be appropriately reloaded. 
+
+Finally each func account needs to create the ngi_pipeline dirs for logs and dbs in respective project area. The `funk_004` user should e.g run `/lupus/ngi/resources/create_ngi_pipeline_dirs.sh ngi2016001`.
 
 ## Note on re-compiling software
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,15 @@ A manual step is required for generating the GATK indices. After everything has 
 
 This repo should be checked out to e.g. `/lupus/ngi/irma3/deploy`. Then the file `bootstrap/bashrc` should be copied to `/lupus/ngi/irma3/bashrc` and sourced every time a user wants to work. 
 
-The latest version of virtualenv was downloaded and then locally run to setup a virtual Python environment: `/lupus/ngi/irma3/virtualenv-15.0.0/virtualenv.py -p /usr/bin/python2.7 /lupus/ngi/irma3/ansible-env`. 
+The latest version of virtualenv was downloaded and then locally run to setup a virtual Python environment: `/lupus/ngi/irma3/virtualenv-15.0.0/virtualenv.py -p /usr/bin/python2.7 /lupus/ngi/irma3/ansible-env`.  
 
 After activating the environment with `source /lupus/ngi/irma3/ansible-env/bin/activate` Ansible was installed with `pip install ansible`.
  
-Then anaconda was downloaded manually (**TODO: do this in the playbook instead?**) and installed via the interactive guide under `/lupus/ngi/sw/anaconda` (some Ansible roles later uses anaconda to setup the NGI virtual environment.)
+Then anaconda was downloaded manually (**TODO: do this in the playbook instead?**) and installed via the interactive guide under `/lupus/ngi/sw/anaconda` (some Ansible roles later uses anaconda to setup the NGI virtual environment.). 
 
 To sync over data to the cluster we need the pexpect Python module. Load the ansible-env Python environment and then do a `pip install pexpect`. 
+
+Finnally the setgid flag was set by running `chmod -R g+s /lupus/ngi/sw/ /lupus/ngi/irma3/`.
 
 ## Some operational dependencies
 

--- a/host_vars/127.0.0.1/main.yml
+++ b/host_vars/127.0.0.1/main.yml
@@ -18,23 +18,30 @@ bash_env_script: sourceme_common.sh
 
 ngi_pipeline_repo: https://github.com/NationalGenomicsInfrastructure/ngi_pipeline.git
 ngi_pipeline_dest: "{{ root_path }}/sw/ngi_pipeline"
-ngi_pipeline_version: 33d180be2b98feb90838c57f4dbbd75440308c69 
+ngi_pipeline_version: 3cd78a2b58b0dc0b9ae2bd193c2038744a07e73a
 ngi_pipeline_venv: "{{ root_path }}/sw/anaconda/envs/NGI"
 
 ngi_pipeline_conf: "{{ root_path }}/conf/"
-ngi_pipeline_db: "{{ root_path }}/db/"
-ngi_pipeline_logs: "{{ root_path }}/log/"
 ngi_resources: "{{ root_path }}/resources/"
 
 ngi_pipeline_sthlm_delivery: ngi2016003
 ngi_pipeline_upps_delivery: ngi2016001
+
+ngi_pipeline_sthlm_path: "/proj/{{ ngi_pipeline_sthlm_delivery }}/private/ngi_pipeline/"
+ngi_pipeline_upps_path: "/proj/{{ ngi_pipeline_upps_delivery }}/private/ngi_pipeline/"
+
+ngi_pipeline_log_sthlm: "{{ ngi_pipeline_sthlm_path }}/ngi_pipeline.log"
+ngi_pipeline_log_upps: "{{ ngi_pipeline_upps_path }}/ngi_pipeline.log"
+
+ngi_pipeline_db_upps: "{{ ngi_pipeline_upps_path }}/db/records_db_upps.sql"
+ngi_pipeline_db_sthlm: "{{ ngi_pipeline_sthlm_path }}/db/records_db_sthlm.sql"
+
 
 ngi_piper_repo: https://github.com/NationalGenomicsInfrastructure/piper.git
 ngi_piper_src_dest: "{{ root_path }}/sw/piper_src"
 ngi_piper_bin_dest: "{{ root_path }}/sw/piper"
 ngi_piper_version: 051ca55f20949279b68fc1c96ce071b117f57a05
 
-# TODO: Where to store API token? How to reach charon-dev, if necessary? 
 # charon settings are fetched from charon_credentials.yml for now, 
 # that is not checked into repo.  
 

--- a/host_vars/127.0.0.1/main.yml
+++ b/host_vars/127.0.0.1/main.yml
@@ -30,8 +30,8 @@ ngi_pipeline_upps_delivery: ngi2016001
 ngi_pipeline_sthlm_path: "/proj/{{ ngi_pipeline_sthlm_delivery }}/private/ngi_pipeline/"
 ngi_pipeline_upps_path: "/proj/{{ ngi_pipeline_upps_delivery }}/private/ngi_pipeline/"
 
-ngi_pipeline_log_sthlm: "{{ ngi_pipeline_sthlm_path }}/ngi_pipeline.log"
-ngi_pipeline_log_upps: "{{ ngi_pipeline_upps_path }}/ngi_pipeline.log"
+ngi_pipeline_log_sthlm: "{{ ngi_pipeline_sthlm_path }}/log/ngi_pipeline.log"
+ngi_pipeline_log_upps: "{{ ngi_pipeline_upps_path }}/log/ngi_pipeline.log"
 
 ngi_pipeline_db_upps: "{{ ngi_pipeline_upps_path }}/db/records_db_upps.sql"
 ngi_pipeline_db_sthlm: "{{ ngi_pipeline_sthlm_path }}/db/records_db_sthlm.sql"

--- a/roles/ngi_pipeline/defaults/main.yml
+++ b/roles/ngi_pipeline/defaults/main.yml
@@ -7,9 +7,3 @@ sthlm_config: irma_ngi_config_sthlm.yaml
 bash_env_site_script: sourceme_site.sh.j2
 bash_env_upps_script: sourceme_upps.sh
 bash_env_sthlm_script: sourceme_sthlm.sh
-
-ngi_pipeline_log_upps: ngi_pipeline_upps.log
-ngi_pipeline_log_sthlm: ngi_pipeline_sthlm.log
-
-records_db_upps: records_db_upps.sql
-records_db_sthlm: records_db_sthlm.sql

--- a/roles/ngi_pipeline/files/create_ngi_pipeline_dirs.sh
+++ b/roles/ngi_pipeline/files/create_ngi_pipeline_dirs.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Minimalistic script that initiates project/site specific
+# directories for ngi_pipeline logs and dbs under respective
+# site's project dirs.
+
+# To be run as respective func account:
+#
+# funk_004 -> ngi2016001
+# funk_006 -> ngi2016003
+
+if [ $# -ne 1 ]; then
+        echo "$0: usage: create_ngi_pipeline_dirs.sh <project id>"
+        exit 1
+fi
+
+mkdir -p /proj/$1/private/ngi_pipeline/log
+mkdir -p /proj/$1/private/ngi_pipeline/db
+find /proj/$1/private/ngi_pipeline -ls

--- a/roles/ngi_pipeline/tasks/main.yml
+++ b/roles/ngi_pipeline/tasks/main.yml
@@ -33,7 +33,7 @@
 
 # Set Uppsala specific variables
 - set_fact:
-    records_db: "{{ records_db_upps }}"
+    ngi_pipeline_db: "{{ ngi_pipeline_db_upps }}"
     ngi_pipeline_slurm_project: "{{ ngi_pipeline_upps_delivery }}"
     ngi_pipeline_log: "{{ ngi_pipeline_log_upps }}"
   tags: ngi_pipeline
@@ -44,7 +44,7 @@
 
 # Set Stockholm specific variables
 - set_fact:
-    records_db: "{{ records_db_sthlm }}"
+    ngi_pipeline_db: "{{ ngi_pipeline_db_sthlm }}"
     ngi_pipeline_slurm_project: "{{ ngi_pipeline_sthlm_delivery }}"
     ngi_pipeline_log: "{{ ngi_pipeline_log_sthlm }}"
   tags: ngi_pipeline
@@ -83,12 +83,8 @@
   copy: src="fastq_screen.irma.conf" dest="{{ ngi_pipeline_conf }}" 
   tags: ngi_pipeline 
 
-- name: create ngi_pipeline log dir
-  file: name={{ ngi_pipeline_logs }} state=directory group=ngi mode=g+s
-  tags: ngi_pipeline
-
-- name: create db dir for ngi_pipeline
-  file: name={{ ngi_pipeline_db }} state=directory group=ngi mode=g+s
+- name: deploy script for creating site specific ngi_pipeline dirs for logs and db
+  copy: src=create_ngi_pipeline_dirs.sh dest={{ ngi_resources }}
   tags: ngi_pipeline
 
 - name: add anaconda path to sourceme script

--- a/roles/ngi_pipeline/tasks/main.yml
+++ b/roles/ngi_pipeline/tasks/main.yml
@@ -94,6 +94,6 @@
 - name: add anaconda path to sourceme script
   lineinfile: dest={{ ngi_pipeline_conf }}/{{ bash_env_script }}
               line='export PATH={{ anaconda_path }}/bin:$PATH'
-              backup=yes
+              backup=no
   tags: ngi_pipeline
 

--- a/roles/ngi_pipeline/templates/irma_ngi_config.yaml.j2
+++ b/roles/ngi_pipeline/templates/irma_ngi_config.yaml.j2
@@ -3,7 +3,7 @@
 
 # TODO: Deploy the correct version of the database. 
 database:
-    record_tracking_db_path: {{ ngi_pipeline_db }}/{{ records_db }}
+    record_tracking_db_path: {{ ngi_pipeline_db }}
 
 environment:
     project_id: {{ ngi_pipeline_slurm_project }}
@@ -83,7 +83,7 @@ paths: # Hard code paths here if you are that kind of a person
     references:
 
 logging: 
-    log_file: "{{ ngi_pipeline_logs }}/{{ ngi_pipeline_log }}" 
+    log_file: "{{ ngi_pipeline_log }}" 
 
 mail:
     recipient: {{ recipient_mail }}

--- a/roles/piper/tasks/prereqs.yml
+++ b/roles/piper/tasks/prereqs.yml
@@ -32,6 +32,6 @@
 - name: add java and maven to the user's path via sourceme script 
   lineinfile: dest={{ ngi_pipeline_conf }}/{{ bash_env_script }}
               line='export PATH={{ java_path }}/bin:{{ maven_path }}/bin:$PATH'
-              backup=yes
+              backup=no
   tags: ngi_piper 
 


### PR DESCRIPTION
- Mention required setgid changes and don't keep backups of confs 
- Create log and db dir under project areas instead. Requires that the script `/lupus/ngi/resources/create_ngi_pipeline_dirs.sh` is run by a funk account with a specific project id as argument. 
- Use the delete flag when syncing. 