### PR TITLE
Newer version of openssl for openresty

### DIFF
--- a/host_vars/127.0.0.1/main.yml
+++ b/host_vars/127.0.0.1/main.yml
@@ -15,6 +15,8 @@ home_path: /tmp
 # Name of the script that should be sourced from the user to get the 
 # relevant environment variables setup. Perhaps move this to defaults vars.  
 bash_env_script: sourceme_common.sh
+bash_env_upps_script: sourceme_upps.sh
+bash_env_sthlm_script: sourceme_sthlm.sh
 
 ngi_pipeline_repo: https://github.com/NationalGenomicsInfrastructure/ngi_pipeline.git
 ngi_pipeline_dest: "{{ root_path }}/sw/ngi_pipeline"

--- a/roles/tarzan/README.md
+++ b/roles/tarzan/README.md
@@ -8,3 +8,4 @@ TODO: Backup of Cassandra db somehow? Or perhaps unnecessary if we think we can 
 TODO: Authentication to Cassandra? Or is it enough that we're running on a secure system? 
 TODO: Have serf traffic encrypted? 
 TODO: Kong and Serf file perms
+TODO: Permissions to the admin interface? 

--- a/roles/tarzan/defaults/main.yml
+++ b/roles/tarzan/defaults/main.yml
@@ -33,6 +33,12 @@ openresty_file: openresty-1.9.7.3.tar.gz
 openresty_version: 1.9.7.3
 openresty_dest: "{{ tarzan_dest }}/openresty/"
 
+# openresty depends on a newer version of openssl
+openssl_url: https://www.openssl.org/source/openssl-1.0.2f.tar.gz
+openssl_file: openssl-1.0.2f.tar.gz
+openssl_version: 1.0.2f
+openssl_dest: "{{ tarzan_dest }}/openssl/"
+
 # kong depends on serf for service/cluster discovery 
 serf_url: https://releases.hashicorp.com/serf/0.7.0/serf_0.7.0_linux_amd64.zip
 serf_file: serf_0.7.0_linux_amd64.zip
@@ -46,3 +52,10 @@ tarzan_env_path: "{{ luajit_dest }}/{{ luajit_version }}/bin:{{ luarocks_dest }}
 tarzan_log_dest: "{{ ngi_pipeline_upps_path }}/log/tarzan/"
 tarzan_db_dest: "{{ ngi_pipeline_upps_path }}/db/tarzan/"
 cassandra_db_dest: "{{ tarzan_db_dest }}/cassandra" 
+
+# To get Tarzan to work lua_path and lua_cpath were generated from a working luarocks 
+# installation on the cluster, and then running the command `luarocks path`, 
+# and then substituting some of the values to respective Ansible variables. 
+lua_path: "/home/funk_004/.luarocks/share/lua/5.1/?.lua;/home/funk_004/.luarocks/share/lua/5.1/?/init.lua;{{ luarocks_dest }}/{{ luarocks_version }}/share/lua/5.1/?.lua;{{ luarocks_dest }}/{{ luarocks_version }}/share/lua/5.1/?/init.lua;{{ luarocks_dest }}/{{ luarocks_version }}/share/lua/5.1/*/init.lua"
+lua_cpath: "/home/funk_004/.luarocks/lib/lua/5.1/?.so;{{ luarocks_dest }}/{{ luarocks_version }}/lib/lua/5.1/?.so;./?.so;/usr/local/lib/lua/5.1/?.so;{{ luajit_dest }}/{{ luajit_version }}/lib/lua/5.1/?.so;/usr/local/lib/lua/5.1/loadall.so"
+

--- a/roles/tarzan/defaults/main.yml
+++ b/roles/tarzan/defaults/main.yml
@@ -34,7 +34,7 @@ openresty_version: 1.9.7.3
 openresty_dest: "{{ tarzan_dest }}/openresty/"
 
 # openresty depends on a newer version of openssl
-openssl_url: https://www.openssl.org/source/openssl-1.0.2f.tar.gz
+openssl_url: https://www.openssl.org/source/old/1.0.2/openssl-1.0.2f.tar.gz
 openssl_file: openssl-1.0.2f.tar.gz
 openssl_version: 1.0.2f
 openssl_dest: "{{ tarzan_dest }}/openssl/"

--- a/roles/tarzan/tasks/dependencies.yml
+++ b/roles/tarzan/tasks/dependencies.yml
@@ -71,7 +71,19 @@
     creates: "{{ luarocks_dest }}/{{ luarocks_version }}/bin/luarocks"
   tags: tarzan 
 
-# Add luarocks to path (see .bashrc @ tarzan vm)
+- name: create openssl destination directory
+  file: path={{ openssl_dest }} state=directory mode=g+s
+  tags: tarzan
+
+- name: download openssl archive
+  get_url:
+    url: "{{ openssl_url }}"
+    dest: "{{ openssl_dest }}/{{ openssl_file }}"
+  tags: tarzan
+
+- name: unpack openssl to destination
+  unarchive: src="{{ openssl_dest }}/{{ openssl_file }}" dest={{ openssl_dest }}/ copy=no creates={{ openssl_dest }}/{{ openssl_version }}/bin/openssl
+  tags: tarzan
 
 - name: create openresty destination directory
   file: path={{ openresty_dest }} state=directory mode=g+s
@@ -88,7 +100,7 @@
   tags: tarzan
 
 - name: configure openresty
-  shell: "./configure --with-pcre-jit --with-ipv6 --with-http_realip_module --with-http_ssl_module --with-http_stub_status_module --with-luajit={{ luajit_dest }}/{{ luajit_version }} --prefix={{ openresty_dest }}/{{ openresty_version }}" 
+  shell: "./configure --with-pcre-jit --with-ipv6 --with-http_realip_module --with-http_ssl_module --with-http_stub_status_module --with-luajit={{ luajit_dest }}/{{ luajit_version }} --prefix={{ openresty_dest }}/{{ openresty_version }} --with-openssl={{ openssl_dest }}/openssl-{{ openssl_version }}/" 
   args: 
     chdir: "{{ openresty_dest }}/openresty-{{ openresty_version }}"
     creates: "{{ openresty_dest }}/{{ openresty_version }}/bin/resty"
@@ -100,8 +112,6 @@
     chdir: "{{ openresty_dest}}/openresty-{{ openresty_version }}" 
     creates: "{{ openresty_dest }}/{{ openresty_version }}/bin/resty"
   tags: tarzan 
-
-# Add openresty to path? 
 
 - name: create cassandra destination directory
   file: path={{ cassandra_dest }} state=directory mode=g+s

--- a/roles/tarzan/tasks/main.yml
+++ b/roles/tarzan/tasks/main.yml
@@ -16,9 +16,20 @@
               backup=no
   tags: tarzan
 
+- name: add the lua_path to funk_004's environment via the sourceme_upps script
+  lineinfile: dest={{ ngi_pipeline_conf }}/{{ bash_env_upps_script }}
+              line='export LUA_PATH={{ lua_path }}'
+              backup=no
+  tags: tarzan
+
+- name: add the lua_cpath to funk_004's environment via the sourceme_upps script
+  lineinfile: dest={{ ngi_pipeline_conf }}/{{ bash_env_upps_script }}
+              line='export LUA_CPATH={{ lua_cpath }}'
+              backup=no
+  tags: tarzan
+
 # TODO: have a subdir for all tarzan confs? 
 
-# TODO: Deploy/Config a kong.yml
 - name: deploy config for kong
   template: src="kong.yml.j2" dest="{{ ngi_pipeline_conf }}/webproxy.yml"
   tags: tarzan
@@ -31,5 +42,4 @@
   tags: tarzan
 
 # TODO: Update crontab so that it launches the tarzan supervisord
-# TODO: Update the cassandra config 
  


### PR DESCRIPTION
- Compile openresty with newer version of openssl than the one provided from the system. 
- Set correct `LUA_PATH` and `LUA_CPATH` env vars for funk_004 user.

These two changes gets Kong working. After running

- `cassandra -f `
- `kong -c /lupus/ngi/conf/webproxy.yml`

a `curl localhost:8001` will return a JSON payload from the Kong server. 