### PR TITLE
Tarzan tuning

### DIFF
--- a/roles/tarzan/defaults/main.yml
+++ b/roles/tarzan/defaults/main.yml
@@ -56,6 +56,9 @@ cassandra_db_dest: "{{ tarzan_db_dest }}/cassandra"
 # To get Tarzan to work lua_path and lua_cpath were generated from a working luarocks 
 # installation on the cluster, and then running the command `luarocks path`, 
 # and then substituting some of the values to respective Ansible variables. 
-lua_path: "/home/funk_004/.luarocks/share/lua/5.1/?.lua;/home/funk_004/.luarocks/share/lua/5.1/?/init.lua;{{ luarocks_dest }}/{{ luarocks_version }}/share/lua/5.1/?.lua;{{ luarocks_dest }}/{{ luarocks_version }}/share/lua/5.1/?/init.lua;{{ luarocks_dest }}/{{ luarocks_version }}/share/lua/5.1/*/init.lua"
-lua_cpath: "/home/funk_004/.luarocks/lib/lua/5.1/?.so;{{ luarocks_dest }}/{{ luarocks_version }}/lib/lua/5.1/?.so;./?.so;/usr/local/lib/lua/5.1/?.so;{{ luajit_dest }}/{{ luajit_version }}/lib/lua/5.1/?.so;/usr/local/lib/lua/5.1/loadall.so"
+# The two last paths in both vars seems to be necessary so that we do not 
+# get warnings the module system lmod which is using lua as well. This 
+# might be a future error source.
+lua_path: "/home/funk_004/.luarocks/share/lua/5.1/?.lua;/home/funk_004/.luarocks/share/lua/5.1/?/init.lua;{{ luarocks_dest }}/{{ luarocks_version }}/share/lua/5.1/?.lua;{{ luarocks_dest }}/{{ luarocks_version }}/share/lua/5.1/?/init.lua;{{ luarocks_dest }}/{{ luarocks_version }}/share/lua/5.1/*/init.lua;;/usr/share/lua/5.1/?.lua;/usr/share/lua/5.1/?/init.lua"
+lua_cpath: "/home/funk_004/.luarocks/lib/lua/5.1/?.so;{{ luarocks_dest }}/{{ luarocks_version }}/lib/lua/5.1/?.so;./?.so;/usr/local/lib/lua/5.1/?.so;{{ luajit_dest }}/{{ luajit_version }}/lib/lua/5.1/?.so;/usr/local/lib/lua/5.1/loadall.so;/usr/lib64/lua/5.1/?.so;/usr/lib64/lua/5.1/loadall.so"
 

--- a/roles/tarzan/tasks/main.yml
+++ b/roles/tarzan/tasks/main.yml
@@ -18,13 +18,13 @@
 
 - name: add the lua_path to funk_004's environment via the sourceme_upps script
   lineinfile: dest={{ ngi_pipeline_conf }}/{{ bash_env_upps_script }}
-              line='export LUA_PATH={{ lua_path }}'
+              line='export LUA_PATH="{{ lua_path }}"'
               backup=no
   tags: tarzan
 
 - name: add the lua_cpath to funk_004's environment via the sourceme_upps script
   lineinfile: dest={{ ngi_pipeline_conf }}/{{ bash_env_upps_script }}
-              line='export LUA_CPATH={{ lua_cpath }}'
+              line='export LUA_CPATH="{{ lua_cpath }}"'
               backup=no
   tags: tarzan
 

--- a/roles/tarzan/templates/kong.yml.j2
+++ b/roles/tarzan/templates/kong.yml.j2
@@ -174,7 +174,7 @@ send_anonymous_reports: false
 ## /!\ BE CAREFUL
 nginx: |
   {{user}}
-  worker_processes auto;
+  worker_processes 4;
   error_log logs/error.log error;
   daemon on;
 

--- a/roles/tarzan/templates/kong.yml.j2
+++ b/roles/tarzan/templates/kong.yml.j2
@@ -32,27 +32,27 @@ nginx_working_dir: [% tarzan_log_dest %]
 
 ######
 ## Address and port on which the server will accept HTTP requests, consumers will make requests on this port.
-# proxy_listen: "0.0.0.0:8000"
+proxy_listen: "0.0.0.0:8888"
 
 ######
 ## Same as proxy_listen, but for HTTPS requests.
-# proxy_listen_ssl: "0.0.0.0:8443"
+proxy_listen_ssl: "0.0.0.0:4444"
 
 ######
 ## Address and port on which the admin API will listen to. The admin API is a private API which lets you
 ## manage your Kong infrastructure. It needs to be secured appropriately.
-# admin_api_listen: "0.0.0.0:8001"
+admin_api_listen: "127.0.0.1:8001"
 
 ######
 ## Address and port used by the node to communicate with other Kong nodes in the cluster with both UDP and
 ## TCP messages. All the nodes in the cluster must be able to communicate with this node on this address.
 ## Only IPv4 addresses are allowed (no hostnames).
-# cluster_listen: "0.0.0.0:7946"
+cluster_listen: "127.0.0.1:7946"
 
 ######
 ## Address and port used by the node to communicate with the local clustering agent (TCP only, and local only).
 ## Used internally by this Kong node. Only IPv4 addresses are allowed (no hostnames).
-# cluster_listen_rpc: "127.0.0.1:7373"
+cluster_listen_rpc: "127.0.0.1:7373"
 
 ######
 ## The path to the SSL certificate and key that Kong will use when listening on the `https` port.


### PR DESCRIPTION
- Make serf and Kong admin interface only listen to localhost.
- Change kong https port to 4444 and non-https to 8888
- Need escaping of lua env vars to not get bash errors 
- Need to add some system lua paths to the lua envs for module system lmod to function, as it is also using lua. Might be a future error source.
- Spawn 4 nginx worker processes instead of the default "auto", which on irma1 will spawn 16 processes (number of CPU cores)